### PR TITLE
Make it possible to style the Icon color  with a color prop

### DIFF
--- a/src/Icon.js
+++ b/src/Icon.js
@@ -9,7 +9,7 @@ const SvgWrapper = styled.span`
   min-width: ${props => `${props.iconSize || 32}px`};
   min-height: ${props => `${props.iconSize || 32}px`};
   position: relative;
-  color: inherit;
+  color: ${props => props.color} !important;
 `
 
 const InlineSvg = styled.svg`
@@ -24,8 +24,8 @@ const InlineSvg = styled.svg`
   fill: currentColor;
 `
 
-export const Icon = ({ size = 32, children, a11yTitle, ...props }) => (
-  <SvgWrapper iconSize={size} className="icon" {...props}>
+export const Icon = ({ size = 32, children, a11yTitle, color, ...props }) => (
+  <SvgWrapper iconSize={size} className="icon" color={color} {...props}>
     <InlineSvg
       aria-label={a11yTitle}
       fillRule="evenodd"

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Icon matches snapshot 1`] = `
 <span
-  class="icon css-yj93w3-SvgWrapper elpsssu0"
+  class="icon css-qgpsiz-SvgWrapper elpsssu0"
 >
   <svg
     aria-label="Download"

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -1,6 +1,11 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import * as Icon from './'
+import styled from '@emotion/styled'
+
+const StyledAlert = styled(Icon.Alert)`
+  color: blue;
+`
 
 storiesOf('Comets', module).add('all', () => (
   <div
@@ -10,9 +15,9 @@ storiesOf('Comets', module).add('all', () => (
       gridTemplateColumns: 'repeat(auto-fill, 32px)',
     }}
   >
-    <Icon.Alert title="Alert" />
+    <StyledAlert title="Alert" />
     <Icon.AlertOff title="AlertOff" />
-    <Icon.Android title="Android" />
+    <Icon.Android title="Android" color="green" />
     <Icon.Apple title="Apple" />
     <Icon.ArrowDown title="ArrowDown" />
     <Icon.ArrowDownRounded title="ArrowDownRounded" />
@@ -24,7 +29,7 @@ storiesOf('Comets', module).add('all', () => (
     <Icon.CalendarWeekend title="CalendarWeekend" />
     <Icon.Cart title="Cart" />
     <Icon.Chat title="Chat" />
-    <Icon.Checkmark title="Checkmark" />
+    <Icon.Checkmark title="Checkmark" color="lightgreen" />
     <Icon.CheckmarkRounded title="CheckmarkRounded" />
     <Icon.ChevronDown title="ChevronDown" />
     <Icon.ChevronDownAlt title="ChevronDownAlt" />


### PR DESCRIPTION
Sometimes we import an icon in our project that *only* needs a different color. It feels a bit weird to me to make a whole new styled component for this. To me it looks way easier to just pass a color prop. This PR is an attempt to do that.

## How does it work

* If nothing is supplied (no `color` prop or not used as styled component) the icon will stay black.

* If the `color` prop is supplied, it will have the color from the `color` prop

* If the `color` prop is supplied, but the icon is also used as styled component with a color property it will overwrite the `color` prop