### PR TITLE
refactor(icon): refactor the way color is supplied to an icon

### DIFF
--- a/src/Icon.js
+++ b/src/Icon.js
@@ -9,7 +9,12 @@ const SvgWrapper = styled.span`
   min-width: ${props => `${props.iconSize || 32}px`};
   min-height: ${props => `${props.iconSize || 32}px`};
   position: relative;
-  color: ${props => props.color} !important;
+
+  /*
+    Overwrite the color from a styled component if
+    there is a color prop supplied
+  */
+  color: ${({ color }) => (color ? `${color} !important` : 'inherit')};
 `
 
 const InlineSvg = styled.svg`

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Icon matches snapshot 1`] = `
 <span
-  class="icon css-qgpsiz-SvgWrapper elpsssu0"
+  class="icon css-yj93w3-SvgWrapper elpsssu0"
 >
   <svg
     aria-label="Download"

--- a/src/index.stories.js
+++ b/src/index.stories.js
@@ -7,6 +7,10 @@ const StyledAlert = styled(Icon.Alert)`
   color: blue;
 `
 
+const StyledAlertOff = styled(Icon.AlertOff)`
+  color: blue;
+`
+
 storiesOf('Comets', module).add('all', () => (
   <div
     style={{
@@ -15,8 +19,8 @@ storiesOf('Comets', module).add('all', () => (
       gridTemplateColumns: 'repeat(auto-fill, 32px)',
     }}
   >
-    <StyledAlert title="Alert" />
-    <Icon.AlertOff title="AlertOff" />
+    <StyledAlert title="Alert" color="red" />
+    <StyledAlertOff title="AlertOff" />
     <Icon.Android title="Android" color="green" />
     <Icon.Apple title="Apple" />
     <Icon.ArrowDown title="ArrowDown" />


### PR DESCRIPTION
Small code improvement and explanation comment added.

<img width="830" alt="Screenshot 2020-07-28 at 15 17 02" src="https://user-images.githubusercontent.com/14276144/88670765-c20de480-d0e5-11ea-8677-a0a48304085c.png">
 