### PR TITLE
fix: add files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Icon library for the TicketSwap product",
   "main": "dist/comets.js",
   "module": "dist/comets.es.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "jest",
     "commit": "git-cz",


### PR DESCRIPTION
we're having problems with packaging the library. with this commit we're assigning dist as the files
to package in our package.json file